### PR TITLE
Add React PDF viewer example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# PdfDocument
+# PdfDocument React Example
+
+This repository provides a minimal example of a React component that
+uses [`react-pdf`](https://github.com/wojtekmaj/react-pdf) to render a
+PDF file inside the browser.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+   This will open a browser window with the example viewer.
+
+The component `PdfDocument` expects a `file` prop containing the path to a
+PDF document and renders the first page.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>PDF Document Viewer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="dist/bundle.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "pdfdocument",
+  "version": "1.0.0",
+  "description": "Example React component for viewing PDFs",
+  "main": "index.js",
+  "scripts": {
+    "start": "webpack serve --open",
+    "build": "webpack",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-pdf": "^7.1.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.21.0",
+    "@babel/preset-env": "^7.21.0",
+    "@babel/preset-react": "^7.18.6",
+    "babel-loader": "^9.1.2",
+    "style-loader": "^3.3.3",
+    "css-loader": "^6.8.1",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,10 @@
+import PdfDocument from './PdfDocument';
+
+export default function App() {
+  return (
+    <div>
+      <h1>PDF Viewer Example</h1>
+      <PdfDocument file="sample.pdf" />
+    </div>
+  );
+}

--- a/src/PdfDocument.jsx
+++ b/src/PdfDocument.jsx
@@ -1,0 +1,12 @@
+import { Document, Page, pdfjs } from 'react-pdf';
+import 'react-pdf/dist/esm/Page/AnnotationLayer.css';
+
+pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
+
+export default function PdfDocument({ file }) {
+  return (
+    <Document file={file}>
+      <Page pageNumber={1} />
+    </Document>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,36 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, '/'),
+    },
+    hot: true,
+  },
+};


### PR DESCRIPTION
## Summary
- add React-based example component `PdfDocument`
- include `App` component and entry point
- add webpack config and package.json
- provide minimal HTML template
- update README with instructions
- ignore build artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685246c354e8832da14c7d07b564b8d6